### PR TITLE
fix[1608709293]: Change the name of the quiz depending on the subject.

### DIFF
--- a/Packages/Sources/QuizFeature/QuizView.swift
+++ b/Packages/Sources/QuizFeature/QuizView.swift
@@ -101,9 +101,10 @@ public struct QuizView: View {
     }
 
     var titleText: some View {
-        Text("Zasady Lotu")
-            .font(.headline.bold())
-            .lineLimit(1)
+        Text(store.subject.title)
+            .font(.headline)
+            .multilineTextAlignment(.center)
+            .lineLimit(2)
     }
 
     public init(store: StoreOf<Quiz>) {


### PR DESCRIPTION
Make smaller font and change line limit to 2

![Simulator Screenshot - iPhone 15 - 2024-08-27 at 21 03 49](https://github.com/user-attachments/assets/c6f6988e-99aa-4728-9860-04ec70e07eee)
